### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 ## Descrizione
 Questa applicazione calcola gli indici PMV (Predicted Mean Vote) e PPD (Predicted Percentage of Dissatisfied), utilizzati per valutare il comfort termico in ambienti chiusi. Il progetto rispetta le normative UNI EN ISO 7730 e il D.Lgs. 81/08.
-
 ---
 
 ## Funzionalità


### PR DESCRIPTION
## Summary
- fix word wrap in README description

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68405a177e088323882329ce0f991485