### PR TITLE
Correzione layout e aggiunta licenza

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -1,4 +1,10 @@
-import streamlit as st
+# Questo file fa parte del progetto Microclima-Streamlit.
+#
+# Microclima-Streamlit è distribuito sotto la licenza GNU General Public License v3.0.
+# Puoi utilizzare, modificare e distribuire questo software secondo i termini della licenza.
+#
+# Per maggiori dettagli, consulta il file LICENSE o visita https://www.gnu.org/licenses/gpl-3.0.html.
+
 import streamlit as st
 
 # Modifica CSS per sidebar più larga e non centrata


### PR DESCRIPTION
## Summary
- rimossa la linea `import streamlit as st` duplicata in `layout.py`
- aggiunto il commento di licenza come negli altri moduli

## Testing
- `python -m py_compile layout.py`


------
https://chatgpt.com/codex/tasks/task_e_684080b82d948323a96e7421bdabf12f