### PR TITLE
Add license header to spiegazioni_indici

### DIFF
--- a/spiegazioni_indici.py
+++ b/spiegazioni_indici.py
@@ -1,3 +1,10 @@
+# Questo file fa parte del progetto Microclima-Streamlit.
+#
+# Microclima-Streamlit è distribuito sotto la licenza GNU General Public License v3.0.
+# Puoi utilizzare, modificare e distribuire questo software secondo i termini della licenza.
+#
+# Per maggiori dettagli, consulta il file LICENSE o visita https://www.gnu.org/licenses/gpl-3.0.html.
+
 spiegazioni_indici = {
     "pmv": (
         "Il PMV (Predicted Mean Vote) rappresenta la sensazione termica media prevista "


### PR DESCRIPTION
## Summary
- include GPLv3 license header at top of `spiegazioni_indici.py`

## Testing
- `python -m py_compile layout.py spiegazioni_indici.py`

------
https://chatgpt.com/codex/tasks/task_e_68408b1e79e08323994058758763d41e