### PR TITLE
Aggiunge parametro output_path a genera_report_pdf

### DIFF
--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -9,6 +9,7 @@ from fpdf import FPDF
 from grafici import genera_grafico_pmv_ppd
 import os
 
+
 def genera_report_pdf(
     temp_aria,
     temp_radiante,
@@ -20,6 +21,7 @@ def genera_report_pdf(
     ppd,
     sede,
     descrizione_locale,
+    output_path="report_microclima.pdf",
 ):
     """
     Genera un report PDF con i risultati e il grafico PMV-PPD.
@@ -29,7 +31,7 @@ def genera_report_pdf(
     pdf = FPDF()
     pdf.add_page()
     pdf.set_font("Arial", size=12)
-    pdf.cell(200, 10, txt="Analisi del Microclima Ufficio", ln=True, align='C')
+    pdf.cell(200, 10, txt="Analisi del Microclima Ufficio", ln=True, align="C")
     pdf.ln(10)
 
     # Parametri ambientali
@@ -56,8 +58,7 @@ def genera_report_pdf(
     pdf.ln(85)
 
     # Salva il PDF
-    pdf_path = "report_microclima.pdf"
-    pdf.output(pdf_path)
+    pdf.output(output_path)
 
     # Rimuove il file temporaneo del grafico
     try:
@@ -65,4 +66,4 @@ def genera_report_pdf(
     except OSError:
         pass
 
-    return pdf_path
+    return output_path

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -14,6 +14,7 @@ from pdf_generator import genera_report_pdf
 
 
 def test_pdf_generation_cleanup(tmp_path):
+    output_file = tmp_path / "report_microclima.pdf"
     pdf = genera_report_pdf(
         25.0,
         25.0,
@@ -25,6 +26,8 @@ def test_pdf_generation_cleanup(tmp_path):
         5.0,
         "Sede di test",
         "Locale di prova",
+        output_path=str(output_file),
     )
+    assert pdf == str(output_file)
     assert os.path.exists(pdf)
     os.remove(pdf)


### PR DESCRIPTION
## Summary
- estende `genera_report_pdf` con il parametro opzionale `output_path`
- usa il percorso indicato per salvare il PDF
- aggiorna i test per verificare l'argomento opzionale

## Testing
- `flake8 pdf_generator.py tests/test_pdf_generator.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a2ef5658832386ea17d747f493e4