### PR TITLE
Aggiunge spiegazioni indici nel PDF

### DIFF
--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -7,6 +7,7 @@
 
 from fpdf import FPDF
 from grafici import genera_grafico_pmv_ppd
+from spiegazioni_indici import spiegazioni_indici
 import os
 
 
@@ -73,6 +74,9 @@ def genera_report_pdf(
     pdf.cell(95, 8, txt=f"{pmv:.2f}", ln=True)
     pdf.cell(95, 8, txt="Indice PPD:")
     pdf.cell(95, 8, txt=f"{ppd:.2f}%", ln=True)
+    pdf.multi_cell(0, 8, txt=spiegazioni_indici["pmv"])
+    pdf.ln(1)
+    pdf.multi_cell(0, 8, txt=spiegazioni_indici["ppd"])
     pdf.ln(5)
 
     # Inserimento del grafico nel PDF

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -28,3 +28,38 @@ def test_pdf_generation_cleanup(tmp_path):
     assert pdf == str(output_file)
     assert os.path.exists(pdf)
     os.remove(pdf)
+
+
+def test_pdf_contains_explanations(tmp_path):
+    output_file = tmp_path / "report_microclima.pdf"
+    pdf = genera_report_pdf(
+        25.0,
+        25.0,
+        0.1,
+        50.0,
+        1.2,
+        0.5,
+        0.0,
+        5.0,
+        "Sede di test",
+        "Locale di prova",
+        output_path=str(output_file),
+    )
+    assert pdf == str(output_file)
+    with open(pdf, "rb") as file:
+        data = file.read()
+
+    import re
+    import zlib
+
+    streams = re.findall(rb"stream\n(.+?)\nendstream", data, re.DOTALL)
+    extracted = ""
+    for s in streams:
+        try:
+            extracted += zlib.decompress(s).decode("latin-1")
+        except Exception:
+            continue
+
+    assert "Il PMV \\(Predicted Mean Vote\\)" in extracted
+    assert "Il PPD \\(Predicted Percentage of Dissatisfied\\)" in extracted
+    os.remove(pdf)


### PR DESCRIPTION
## Sommario
- esteso `genera_report_pdf` per inserire le spiegazioni di PMV e PPD
- aggiunto test che verifica la presenza di tali spiegazioni nel PDF

## Test
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840afb984c88323abd518a361722126