### PR TITLE
Aggiunge data nei report e test

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,6 +67,7 @@ if inputs["submit"]:
         ppd,
         inputs["sede"],
         inputs["descrizione_locale"],
+        data=inputs["data"],
     )
     with open(report_pdf, "rb") as file:
         st.download_button(

--- a/layout.py
+++ b/layout.py
@@ -41,6 +41,7 @@ def setup_layout(parametri_definizioni):
 
     sede = st.sidebar.text_input("Sede")
     descrizione_locale = st.sidebar.text_input("Descrizione del locale")
+    data = st.sidebar.date_input("Data")
 
     temp_aria = st.sidebar.number_input(
         "Temperatura aria (°C):", min_value=10.0, max_value=40.0, value=22.0, step=0.1
@@ -87,5 +88,6 @@ def setup_layout(parametri_definizioni):
         "umidita": umidita,
         "metabolismo": metabolismo,
         "isolamento": isolamento,
+        "data": data,
         "submit": submit,
     }

--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -9,6 +9,7 @@ from fpdf import FPDF
 from grafici import genera_grafico_pmv_ppd
 from spiegazioni_indici import spiegazioni_indici
 import os
+import datetime
 
 
 def genera_report_pdf(
@@ -23,10 +24,13 @@ def genera_report_pdf(
     sede,
     descrizione_locale,
     output_path="report_microclima.pdf",
+    data=None,
 ):
     """
     Genera un report PDF con i risultati e il grafico PMV-PPD.
     """
+    if data is None:
+        data = datetime.date.today()
     grafico_path = genera_grafico_pmv_ppd(pmv, ppd)
 
     pdf = FPDF()
@@ -37,6 +41,12 @@ def genera_report_pdf(
     pdf.set_font("Arial", size=10)
     pdf.line(10, pdf.get_y(), 200, pdf.get_y())
     pdf.ln(5)
+
+    # Informazioni generali
+    pdf.cell(60, 8, txt=f"Sede: {sede}", border=0)
+    pdf.cell(80, 8, txt=f"Descrizione: {descrizione_locale}", border=0)
+    pdf.cell(50, 8, txt=f"Data: {data}", ln=True)
+    pdf.ln(3)
 
     # Parametri ambientali
     pdf.cell(0, 8, txt="Parametri ambientali:", ln=True)

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -6,6 +6,7 @@
 # Per maggiori dettagli, consulta il file LICENSE o visita https://www.gnu.org/licenses/gpl-3.0.html.
 
 import os
+import datetime
 
 from pdf_generator import genera_report_pdf
 
@@ -23,6 +24,7 @@ def test_pdf_generation_cleanup(tmp_path):
         5.0,
         "Sede di test",
         "Locale di prova",
+        data=datetime.date(2024, 1, 1),
         output_path=str(output_file),
     )
     assert pdf == str(output_file)
@@ -43,6 +45,7 @@ def test_pdf_contains_explanations(tmp_path):
         5.0,
         "Sede di test",
         "Locale di prova",
+        data=datetime.date(2024, 1, 1),
         output_path=str(output_file),
     )
     assert pdf == str(output_file)
@@ -62,4 +65,5 @@ def test_pdf_contains_explanations(tmp_path):
 
     assert "Il PMV \\(Predicted Mean Vote\\)" in extracted
     assert "Il PPD \\(Predicted Percentage of Dissatisfied\\)" in extracted
+    assert "Data: 2024-01-01" in extracted
     os.remove(pdf)


### PR DESCRIPTION
## Summary
- estende `genera_report_pdf` per includere la data
- visualizza sede, descrizione e data in cima al PDF
- consente di scegliere la data nell'interfaccia Streamlit
- aggiorna i test per verificare la presenza della data

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840b28e788c8323ab2c84a6d51f9bd6