### PR TITLE
Aggiunge gestione oggetti smarriti

### DIFF
--- a/gestione_oggetti.py
+++ b/gestione_oggetti.py
@@ -1,0 +1,202 @@
+# Questo file fa parte del progetto Microclima-Streamlit.
+#
+# Microclima-Streamlit è distribuito sotto la licenza GNU General Public License v3.0.
+# Puoi utilizzare, modificare e distribuire questo software secondo i termini della licenza.
+# Per maggiori dettagli, consulta il file LICENSE o visita https://www.gnu.org/licenses/gpl-3.0.html.
+
+"""Funzioni per la gestione degli oggetti smarriti."""
+
+from __future__ import annotations
+
+import csv
+import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+CAMPI_ATTIVI = [
+    "id",
+    "villa",
+    "proprietario",
+    "descrizione",
+    "data_inserimento",
+    "scadenza_giorni",
+]
+
+CAMPI_ARCHIVIO = CAMPI_ATTIVI + ["stato", "intestatario", "data_ritiro"]
+
+
+# Utility interne
+
+
+def _leggi_csv(percorso: Path, campi: List[str]) -> List[Dict[str, str]]:
+    if not percorso.exists():
+        return []
+    with percorso.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, fieldnames=campi)
+        return list(reader)
+
+
+def _scrivi_csv(percorso: Path, campi: List[str], righe: List[Dict[str, str]]) -> None:
+    with percorso.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=campi)
+        writer.writerows(righe)
+
+
+def _prossimo_id(
+    attivi: List[Dict[str, str]], archivio: List[Dict[str, str]], villa: str
+) -> str:
+    massimo = 0
+    for riga in attivi + archivio:
+        try:
+            numero = int(riga["id"].split("-")[0])
+            massimo = max(massimo, numero)
+        except (KeyError, ValueError, IndexError):
+            continue
+    return f"{massimo + 1:03d}-VL{villa}"
+
+
+# Funzioni pubbliche
+
+
+def inserisci_oggetto(
+    villa: str,
+    proprietario: str,
+    descrizione: str,
+    scadenza_giorni: int = 30,
+    path_attivi: str = "oggetti_attivi.csv",
+    path_archivio: str = "archivio.csv",
+) -> str:
+    """Inserisce un oggetto e restituisce l'ID assegnato."""
+    pa = Path(path_attivi)
+    par = Path(path_archivio)
+    attivi = _leggi_csv(pa, CAMPI_ATTIVI)
+    arch = _leggi_csv(par, CAMPI_ARCHIVIO)
+    nuovo_id = _prossimo_id(attivi, arch, villa)
+    riga = {
+        "id": nuovo_id,
+        "villa": villa,
+        "proprietario": proprietario,
+        "descrizione": descrizione,
+        "data_inserimento": datetime.date.today().isoformat(),
+        "scadenza_giorni": str(scadenza_giorni),
+    }
+    attivi.append(riga)
+    _scrivi_csv(pa, CAMPI_ATTIVI, attivi)
+    return nuovo_id
+
+
+def cerca_per_id(
+    identificativo: str, path_attivi: str = "oggetti_attivi.csv"
+) -> Optional[Dict[str, str]]:
+    pa = Path(path_attivi)
+    attivi = _leggi_csv(pa, CAMPI_ATTIVI)
+    for riga in attivi:
+        if riga.get("id") == identificativo:
+            return riga
+    return None
+
+
+def lista_per_villa(
+    villa: str, path_attivi: str = "oggetti_attivi.csv"
+) -> List[Dict[str, str]]:
+    pa = Path(path_attivi)
+    attivi = _leggi_csv(pa, CAMPI_ATTIVI)
+    return [r for r in attivi if r.get("villa") == villa]
+
+
+def lista_per_proprietario(
+    proprietario: str, path_attivi: str = "oggetti_attivi.csv"
+) -> List[Dict[str, str]]:
+    pa = Path(path_attivi)
+    attivi = _leggi_csv(pa, CAMPI_ATTIVI)
+    return [r for r in attivi if r.get("proprietario") == proprietario]
+
+
+def ritiro_oggetto(
+    identificativo: str,
+    intestatario: str,
+    path_attivi: str = "oggetti_attivi.csv",
+    path_archivio: str = "archivio.csv",
+) -> bool:
+    pa = Path(path_attivi)
+    par = Path(path_archivio)
+    attivi = _leggi_csv(pa, CAMPI_ATTIVI)
+    arch = _leggi_csv(par, CAMPI_ARCHIVIO)
+    for i, riga in enumerate(attivi):
+        if riga.get("id") == identificativo:
+            riga_arch = riga.copy()
+            riga_arch.update(
+                {
+                    "stato": "Ritirato",
+                    "intestatario": intestatario,
+                    "data_ritiro": datetime.date.today().isoformat(),
+                }
+            )
+            arch.append(riga_arch)
+            del attivi[i]
+            _scrivi_csv(pa, CAMPI_ATTIVI, attivi)
+            _scrivi_csv(par, CAMPI_ARCHIVIO, arch)
+            return True
+    return False
+
+
+def archivia_oggetto(
+    identificativo: str,
+    stato: str = "Archiviato",
+    path_attivi: str = "oggetti_attivi.csv",
+    path_archivio: str = "archivio.csv",
+) -> bool:
+    pa = Path(path_attivi)
+    par = Path(path_archivio)
+    attivi = _leggi_csv(pa, CAMPI_ATTIVI)
+    arch = _leggi_csv(par, CAMPI_ARCHIVIO)
+    for i, riga in enumerate(attivi):
+        if riga.get("id") == identificativo:
+            riga_arch = riga.copy()
+            riga_arch.update(
+                {
+                    "stato": stato,
+                    "intestatario": "",
+                    "data_ritiro": datetime.date.today().isoformat(),
+                }
+            )
+            arch.append(riga_arch)
+            del attivi[i]
+            _scrivi_csv(pa, CAMPI_ATTIVI, attivi)
+            _scrivi_csv(par, CAMPI_ARCHIVIO, arch)
+            return True
+    return False
+
+
+def controlla_scadenze(
+    path_attivi: str = "oggetti_attivi.csv",
+    path_archivio: str = "archivio.csv",
+    oggi: Optional[datetime.date] = None,
+) -> None:
+    pa = Path(path_attivi)
+    par = Path(path_archivio)
+    attivi = _leggi_csv(pa, CAMPI_ATTIVI)
+    arch = _leggi_csv(par, CAMPI_ARCHIVIO)
+    today = oggi or datetime.date.today()
+    rimasti = []
+    for riga in attivi:
+        try:
+            inserimento = datetime.date.fromisoformat(riga["data_inserimento"])
+            scadenza = int(riga.get("scadenza_giorni", 30))
+        except Exception:
+            rimasti.append(riga)
+            continue
+        if (today - inserimento).days >= scadenza:
+            riga_arch = riga.copy()
+            riga_arch.update(
+                {
+                    "stato": "Smaltito",
+                    "intestatario": "",
+                    "data_ritiro": today.isoformat(),
+                }
+            )
+            arch.append(riga_arch)
+        else:
+            rimasti.append(riga)
+    _scrivi_csv(pa, CAMPI_ATTIVI, rimasti)
+    _scrivi_csv(par, CAMPI_ARCHIVIO, arch)

--- a/tests/test_gestione_oggetti.py
+++ b/tests/test_gestione_oggetti.py
@@ -1,0 +1,186 @@
+# Questo file fa parte del progetto Microclima-Streamlit.
+#
+# Microclima-Streamlit è distribuito sotto la licenza GNU General Public License v3.0.
+# Puoi utilizzare, modificare e distribuire questo software secondo i termini della licenza.
+# Per maggiori dettagli, consulta il file LICENSE o visita https://www.gnu.org/licenses/gpl-3.0.html.
+
+import csv
+import datetime
+from pathlib import Path
+
+from gestione_oggetti import (
+    archivia_oggetto,
+    cerca_per_id,
+    controlla_scadenze,
+    inserisci_oggetto,
+    lista_per_proprietario,
+    lista_per_villa,
+    ritiro_oggetto,
+)
+
+
+def leggi(path: Path, campi):
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f, fieldnames=campi))
+
+
+def test_id_progressivo(tmp_path):
+    active = tmp_path / "attivi.csv"
+    archive = tmp_path / "archivio.csv"
+    id1 = inserisci_oggetto(
+        "1", "Mario", "Borsa", path_attivi=str(active), path_archivio=str(archive)
+    )
+    id2 = inserisci_oggetto(
+        "2", "Luca", "Chiavi", path_attivi=str(active), path_archivio=str(archive)
+    )
+    assert id1 == "001-VL1"
+    assert id2 == "002-VL2"
+
+
+def test_ricerca_e_lista(tmp_path):
+    active = tmp_path / "attivi.csv"
+    archive = tmp_path / "archivio.csv"
+    oid = inserisci_oggetto(
+        "1", "Mario", "Borsa", path_attivi=str(active), path_archivio=str(archive)
+    )
+    assert cerca_per_id(oid, str(active))["proprietario"] == "Mario"
+    assert lista_per_villa("1", str(active))[0]["id"] == oid
+    assert lista_per_proprietario("Mario", str(active))[0]["id"] == oid
+
+
+def test_ritiro(tmp_path):
+    active = tmp_path / "attivi.csv"
+    archive = tmp_path / "archivio.csv"
+    oid = inserisci_oggetto(
+        "1", "Mario", "Borsa", path_attivi=str(active), path_archivio=str(archive)
+    )
+    assert ritiro_oggetto(oid, "MarioR", str(active), str(archive))
+    attivi = leggi(
+        active,
+        [
+            "id",
+            "villa",
+            "proprietario",
+            "descrizione",
+            "data_inserimento",
+            "scadenza_giorni",
+        ],
+    )
+    arch = leggi(
+        archive,
+        [
+            "id",
+            "villa",
+            "proprietario",
+            "descrizione",
+            "data_inserimento",
+            "scadenza_giorni",
+            "stato",
+            "intestatario",
+            "data_ritiro",
+        ],
+    )
+    assert not attivi
+    assert arch[0]["stato"] == "Ritirato"
+    assert arch[0]["intestatario"] == "MarioR"
+
+
+def test_archiviazione_manuale(tmp_path):
+    active = tmp_path / "attivi.csv"
+    archive = tmp_path / "archivio.csv"
+    oid = inserisci_oggetto(
+        "1", "Mario", "Borsa", path_attivi=str(active), path_archivio=str(archive)
+    )
+    assert archivia_oggetto(oid, "Perso", str(active), str(archive))
+    attivi = leggi(
+        active,
+        [
+            "id",
+            "villa",
+            "proprietario",
+            "descrizione",
+            "data_inserimento",
+            "scadenza_giorni",
+        ],
+    )
+    arch = leggi(
+        archive,
+        [
+            "id",
+            "villa",
+            "proprietario",
+            "descrizione",
+            "data_inserimento",
+            "scadenza_giorni",
+            "stato",
+            "intestatario",
+            "data_ritiro",
+        ],
+    )
+    assert not attivi
+    assert arch[0]["stato"] == "Perso"
+
+
+def test_controllo_scadenze(tmp_path):
+    active = tmp_path / "attivi.csv"
+    archive = tmp_path / "archivio.csv"
+    inserisci_oggetto(
+        "1", "Mario", "Borsa", path_attivi=str(active), path_archivio=str(archive)
+    )
+    rows = leggi(
+        active,
+        [
+            "id",
+            "villa",
+            "proprietario",
+            "descrizione",
+            "data_inserimento",
+            "scadenza_giorni",
+        ],
+    )
+    rows[0]["data_inserimento"] = (
+        datetime.date.today() - datetime.timedelta(days=31)
+    ).isoformat()
+    with active.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "id",
+                "villa",
+                "proprietario",
+                "descrizione",
+                "data_inserimento",
+                "scadenza_giorni",
+            ],
+        )
+        writer.writerows(rows)
+    controlla_scadenze(str(active), str(archive), oggi=datetime.date.today())
+    attivi = leggi(
+        active,
+        [
+            "id",
+            "villa",
+            "proprietario",
+            "descrizione",
+            "data_inserimento",
+            "scadenza_giorni",
+        ],
+    )
+    arch = leggi(
+        archive,
+        [
+            "id",
+            "villa",
+            "proprietario",
+            "descrizione",
+            "data_inserimento",
+            "scadenza_giorni",
+            "stato",
+            "intestatario",
+            "data_ritiro",
+        ],
+    )
+    assert not attivi
+    assert arch[0]["stato"] == "Smaltito"


### PR DESCRIPTION
## Descrizione
- implementa `gestione_oggetti.py` per gestire inserimento, ricerca, ritiro e archiviazione di oggetti
- salva i dati in `oggetti_attivi.csv` e `archivio.csv`
- aggiunge test per le principali funzionalità

## Test
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684294c4c6c08323abd67ce57de95f1c