### PR TITLE
Abilita POST nel frontend HTML

### DIFF
--- a/html_frontend.py
+++ b/html_frontend.py
@@ -6,14 +6,16 @@
 
 """Semplice frontend HTML basato su Flask."""
 
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 
 app = Flask(__name__)
 
 
-@app.route("/", methods=["GET"])
+@app.route("/", methods=["GET", "POST"])
 def index():
-    """Rende la pagina principale."""
+    """Rende la pagina principale e gestisce il form."""
+    if request.method == "POST":
+        return render_template("index.html", message="Dati ricevuti")
     return render_template("index.html")
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,9 @@
 </head>
 <body>
     <h1>Microclima</h1>
+    {% if message %}
+    <p>{{ message }}</p>
+    {% endif %}
     <form method="post">
         <label>Location <input type="text" name="sede"></label><br>
         <label>Description <input type="text" name="descrizione"></label><br>

--- a/tests/test_html_frontend.py
+++ b/tests/test_html_frontend.py
@@ -11,3 +11,6 @@ def test_index_page():
     client = app.test_client()
     response = client.get("/")
     assert response.status_code == 200
+
+    response_post = client.post("/")
+    assert response_post.status_code == 200


### PR DESCRIPTION
## Descrizione
- accetta anche richieste POST nella rotta principale del frontend
- mostra un messaggio di conferma nel template
- estende i test con la chiamata POST

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844955844dc8323a89eaf70f823707a