### PR TITLE
Aggiunge campi commento e firma nel PDF

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,6 +95,8 @@ if inputs["submit"]:
         ppd,
         inputs["sede"],
         inputs["descrizione_locale"],
+        inputs["commento_responsabile"],
+        inputs["firma_responsabile"],
         output_path=report_name,
         data=inputs["data"],
         lingua=inputs["lingua"],

--- a/layout.py
+++ b/layout.py
@@ -96,6 +96,9 @@ def setup_layout():
     )
     st.sidebar.caption(definizioni["impatto_acustico"])
 
+    commento_responsabile = st.sidebar.text_area("Commento del responsabile")
+    firma_responsabile = st.sidebar.text_input("Firma del responsabile")
+
     submit = st.sidebar.button(testi["submit"])
 
     return {
@@ -109,6 +112,8 @@ def setup_layout():
         "isolamento": isolamento,
         "illuminazione": illuminazione,
         "impatto_acustico": impatto_acustico,
+        "commento_responsabile": commento_responsabile,
+        "firma_responsabile": firma_responsabile,
         "data": data,
         "submit": submit,
         "lingua": lang_code,

--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -34,6 +34,8 @@ def genera_report_pdf(
     ppd,
     sede,
     descrizione_locale,
+    commento_responsabile="",
+    firma_responsabile="",
     output_path="report_microclima.pdf",
     data=None,
     lingua="it",
@@ -130,10 +132,17 @@ def genera_report_pdf(
 
     pdf.set_font("Arial", "B", 10)
     pdf.cell(0, 8, txt="Commenti del responsabile:", ln=True)
-    comment_y = pdf.get_y()
-    pdf.rect(10, comment_y, 190, 25)
-    pdf.ln(28)
-    pdf.cell(0, 8, txt="Firma del responsabile: ____________________", ln=True)
+    if commento_responsabile:
+        pdf.multi_cell(0, 8, txt=commento_responsabile)
+    else:
+        pdf.ln(8)
+    pdf.cell(
+        0,
+        8,
+        txt=f"Firma del responsabile: {firma_responsabile}",
+        ln=True,
+    )
+    pdf.ln(20)
 
     space_left = pdf.h - pdf.b_margin - pdf.get_y()
     if space_left < 125:

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -152,6 +152,33 @@ def test_graphs_on_single_page(tmp_path):
     os.remove(pdf)
 
 
+def test_comment_and_signature_present(tmp_path):
+    output_file = tmp_path / "report_microclima.pdf"
+    pdf = genera_report_pdf(
+        25.0,
+        25.0,
+        0.1,
+        50.0,
+        500.0,
+        45.0,
+        1.2,
+        0.5,
+        0.0,
+        5.0,
+        "Sede di test",
+        "Locale di prova",
+        "Test commento",
+        "Mario Rossi",
+        data=datetime.date(2024, 1, 1),
+        output_path=str(output_file),
+    )
+    reader = PyPDF2.PdfReader(pdf)
+    page_two = reader.pages[1].extract_text()
+    assert "Test commento" in page_two
+    assert "Mario Rossi" in page_two
+    os.remove(pdf)
+
+
 def test_pdf_generation_error(tmp_path, monkeypatch):
     def fake_output(self, *args, **kwargs):
         raise IOError("fail")


### PR DESCRIPTION
## Descrizione
- aggiunti i campi di commento e firma nel layout
- passaggio dei nuovi valori all'app e al generatore PDF
- inserimento di commento e firma nel report
- aggiunto test dedicato sul contenuto del PDF

## Note
Nessuna issue collegata.

------
https://chatgpt.com/codex/tasks/task_e_6844a62aca208323bae3e15f27691eef