### PR TITLE
Aggiunge script Streamlit e documentazione

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ L'interfaccia principale è un'app Flask definita in `app.py`; è disponibile an
 5. Oppure avvia la versione Streamlit:
    ```bash
    streamlit run streamlit_main.py
+   # oppure
+   streamlit run streamlit_app.py
    ```
 
 ### Frontend HTML (alternativa)
@@ -183,6 +185,8 @@ The main interface is a Flask app defined in `app.py`; a Streamlit version is al
 5. Or launch the Streamlit version:
    ```bash
    streamlit run streamlit_main.py
+   # or
+   streamlit run streamlit_app.py
    ```
 
 ### HTML Frontend (alternative)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,17 @@
+# Questo file fa parte del progetto Microclima-Streamlit.
+#
+# Microclima-Streamlit è distribuito sotto la licenza GNU General Public License v3.0.
+# Puoi utilizzare, modificare e distribuire questo software secondo i termini della licenza.
+# Per maggiori dettagli, consulta il file LICENSE o visita https://www.gnu.org/licenses/gpl-3.0.html.
+"""Avvia l'interfaccia Streamlit richiamando ``setup_layout``."""
+
+import layout
+
+
+def main() -> None:
+    """Esegue ``setup_layout`` dal modulo ``layout``."""
+    layout.setup_layout()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,0 +1,18 @@
+# Questo file fa parte del progetto Microclima-Streamlit.
+#
+# Microclima-Streamlit è distribuito sotto la licenza GNU General Public License v3.0.
+# Puoi utilizzare, modificare e distribuire questo software secondo i termini della licenza.
+# Per maggiori dettagli, consulta il file LICENSE o visita https://www.gnu.org/licenses/gpl-3.0.html.
+
+import streamlit_app
+
+
+def test_main_chiama_setup(monkeypatch):
+    chiamato = {}
+
+    def finta_setup():
+        chiamato["ok"] = True
+
+    monkeypatch.setattr(streamlit_app.layout, "setup_layout", finta_setup)
+    streamlit_app.main()
+    assert chiamato.get("ok")


### PR DESCRIPTION
## Summary
- aggiunto `streamlit_app.py` per avviare l'interfaccia Streamlit
- documentato l'utilizzo di `streamlit_app.py` nel README
- creato test `test_streamlit_app.py`

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845566a932483238951c5a0650689d7