### PR TITLE
Implementazione download PDF e spiegazioni

### DIFF
--- a/html_frontend.py
+++ b/html_frontend.py
@@ -7,6 +7,8 @@
 """Semplice frontend HTML basato su Flask."""
 
 from flask import Flask, render_template, request
+from spiegazioni_indici import spiegazioni_indici
+from parametri_definizioni import parametri_definizioni
 
 app = Flask(__name__)
 
@@ -28,8 +30,14 @@ def index():
             message=message,
             illuminazione=illuminazione,
             impatto_acustico=impatto_acustico,
+            spiegazioni=spiegazioni_indici,
+            definizioni=parametri_definizioni,
         )
-    return render_template("index.html")
+    return render_template(
+        "index.html",
+        spiegazioni=spiegazioni_indici,
+        definizioni=parametri_definizioni,
+    )
 
 
 if __name__ == "__main__":

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,7 +61,27 @@
         <strong>PMV:</strong> {{ '%.2f'|format(result['pmv']) }}<br>
         <strong>PPD:</strong> {{ '%.2f'|format(result['ppd']) }}%
     </div>
+    <div class="card card-body mt-3">
+        <h5>Spiegazioni</h5>
+        <p>{{ spiegazioni['pmv'] }}</p>
+        <p>{{ spiegazioni['ppd'] }}</p>
+        <a class="btn btn-secondary" href="{{ url_for('download', temp_aria=temp_aria, temp_radiante=temp_radiante, vel_aria=vel_aria, umidita=umidita, clo=clo, met=met, illuminazione=illuminazione, impatto_acustico=impatto_acustico) }}">Scarica Report PDF</a>
+    </div>
     {% endif %}
+
+    <div class="mt-5">
+        <h5>Definizioni parametri</h5>
+        <ul>
+            <li>{{ definizioni['temp_aria'] }}</li>
+            <li>{{ definizioni['temp_radiante'] }}</li>
+            <li>{{ definizioni['vel_aria'] }}</li>
+            <li>{{ definizioni['umidita'] }}</li>
+            <li>{{ definizioni['metabolismo'] }}</li>
+            <li>{{ definizioni['isolamento'] }}</li>
+            <li>{{ definizioni['illuminazione'] }}</li>
+            <li>{{ definizioni['impatto_acustico'] }}</li>
+        </ul>
+    </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ url_for('static', filename='js/script.js') }}"></script>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,49 @@
+import io
+
+import pytest
+from PyPDF2 import PdfReader
+
+from app import app
+from spiegazioni_indici import spiegazioni_indici
+
+
+@pytest.fixture()
+def client():
+    return app.test_client()
+
+
+def test_index_shows_explanations_and_button(client):
+    data = {
+        "temp_aria": "25",
+        "temp_radiante": "25",
+        "umidita": "50",
+        "vel_aria": "0.1",
+        "clo": "0.5",
+        "met": "1.2",
+        "illuminazione": "500",
+        "impatto_acustico": "40",
+    }
+    resp = client.post("/", data=data)
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert "Scarica Report PDF" in html
+    assert spiegazioni_indici["pmv"] in html
+    assert "Definizioni parametri" in html
+    assert "Temperatura dell&#39;aria" in html
+
+
+def test_download_generates_pdf(client):
+    params = {
+        "temp_aria": "25",
+        "temp_radiante": "25",
+        "vel_aria": "0.1",
+        "umidita": "50",
+        "clo": "0.5",
+        "met": "1.2",
+        "illuminazione": "500",
+        "impatto_acustico": "40",
+    }
+    resp = client.get("/download", query_string=params)
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/pdf"
+    PdfReader(io.BytesIO(resp.data))


### PR DESCRIPTION
## Summary
- importa i testi di spiegazione e definizione in app.py
- mostra spiegazioni e definizioni nel template
- aggiunge endpoint `/download` per generare il PDF
- aggiorna html_frontend per compatibilità
- aggiunge test sull'endpoint e sul template

## Testing
- `flake8 app.py tests/test_app.py html_frontend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455916e2848323acdb58ac8fa67984